### PR TITLE
Better fix for playerMove Bug

### DIFF
--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -478,7 +478,6 @@ export class Manager extends EventEmitter {
       state.sessionId = data.d.session_id;
       if (player.voiceChannel !== data.d.channel_id) {
         this.emit("playerMove", player, player.voiceChannel, data.d.channel_id);
-
         data.d.channel_id = player.voiceChannel;
         player.pause(true);
       }

--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -478,7 +478,9 @@ export class Manager extends EventEmitter {
       state.sessionId = data.d.session_id;
       if (player.voiceChannel !== data.d.channel_id) {
         this.emit("playerMove", player, player.voiceChannel, data.d.channel_id);
-        player.voiceChannel = data.d.channel_id;
+
+        data.d.channel_id = player.voiceChannel;
+        player.pause(true);
       }
     }
 

--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -140,7 +140,7 @@ export interface Manager {
    */
   on(
     event: "playerMove",
-    listener: (player: Player, oldChannel: string, newChannel: string) => void
+    listener: (player: Player, initChannel: string, newChannel: string) => void
   ): this;
 
   /**


### PR DESCRIPTION
A fix for the playerMove Bug that prevents a bot from playing music in the initial voice channel again.

Updates the newChannel to current. Currently, a workaround to the bug and allows a nice auto-pause.
The player.pause is needed to ensure that the pause is set to prevent double unpause but also the auto-pause "feature".
Better than not registering the initialization channel to begin with.

No need to update the player.voiceChannel anymore.

Its a matter of changing the old and new channels to initChannel and newChannel, then setting new channel equal to the voiceChannel of the client current channel. This way the initChannel will forever remain the same but the voiceChannel and newChannel will be our deciders in determining whether the same channel or not. 