### PR TITLE
Fix Double Queue Bug

### DIFF
--- a/examples/commands/play.js
+++ b/examples/commands/play.js
@@ -52,7 +52,7 @@ module.exports = {
         if (!player.playing && !player.paused && player.queue.totalSize === res.tracks.length) player.play();
         return message.reply(`enqueuing playlist \`${res.playlist.name}\` with ${res.tracks.length} tracks.`);
       case 'SEARCH_RESULT':
-        let max = 5, collected, filter = (m) => m.author.id === message.author.id && /^(\d+|end)$/i.test(m.content);
+        let max = 5, collected, filter = (m) => m.author.id === message.author.id;
         if (res.tracks.length < max) max = res.tracks.length;
 
         const results = res.tracks
@@ -70,6 +70,11 @@ module.exports = {
         }
 
         const first = collected.first().content;
+        
+        if(isNaN(first)) {
+          if (!player.queue.current) return player.destroy();
+          return;
+        }
 
         if (first.toLowerCase() === 'end') {
           if (!player.queue.current) player.destroy();


### PR DESCRIPTION
Fixed an issue where it will ignore all messages that don't have a number it from the author, now this would be good, however if a user ignores the track selection and starts another play command, bringing up another track selection and they select, it will double queue up the songs.

Example of the issue shown below:
![image](https://user-images.githubusercontent.com/32405102/108614196-6a99e200-7444-11eb-972f-35ffd49a3810.png)
