### PR TITLE
Mixed players from different instances

### DIFF
--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -419,7 +419,7 @@ export class Manager extends EventEmitter {
    * @param options
    */
   public create(options: PlayerOptions): Player {
-    Object.assign({ manager: this, clientId: this.options.clientId }, options);
+    options.manager = this; options.clientId = this.options.clientId;
     if (this.players.has(options.guild)) {
       if(this.players.get(options.guild).manager.options.clientId !== this.options.clientId) {
          return new (Structure.get("Player"))(options);

--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -419,9 +419,9 @@ export class Manager extends EventEmitter {
    * @param options
    */
   public create(options: PlayerOptions): Player {
+    Object.assign({ manager: this, clientId: this.options.clientId }, options);
     if (this.players.has(options.guild)) {
       if(this.players.get(options.guild).manager.options.clientId !== this.options.clientId) {
-         Object.assign({ manager: this, clientId: this.options.clientId }, options);
          return new (Structure.get("Player"))(options);
       }
       return this.players.get(options.guild);

--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -68,7 +68,7 @@ function check(options: ManagerOptions) {
     typeof options.clientName !== "string"
   )
     throw new TypeError('Manager option "clientName" must be a string.');
-  
+
   if (
     typeof options.defaultSearchPlatform !== "undefined" &&
     typeof options.defaultSearchPlatform !== "string"
@@ -420,6 +420,10 @@ export class Manager extends EventEmitter {
    */
   public create(options: PlayerOptions): Player {
     if (this.players.has(options.guild)) {
+      if(this.players.get(options.guild).manager.options.clientId !== this.options.clientId) {
+         Object.assign({ manager: this, clientId: this.options.clientId }, options);
+         return new (Structure.get("Player"))(options);
+      }
       return this.players.get(options.guild);
     }
 
@@ -484,7 +488,7 @@ export class Manager extends EventEmitter {
     } else {
       /* voice state update */
       if (update.user_id !== this.options.clientId) {
-        return;      
+        return;
       }
 
       if (update.channel_id) {

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -111,11 +111,13 @@ export class Player {
       if(this.manager.players.get(options.guild).manager.options.clientId === options.clientId) {
         return this.manager.players.get(options.guild);
       } else {
-        this.manager = options.manager;
+       if(options.manager) this.manager = options.manager;
       }
-      delete this.options.manager; delete this.options.clientId;
     }
-
+    if(this.manager.options.clientId !== options.clientId) {
+      if(options.manager) this.manager = options.manager;
+    }
+    delete this.options.manager; delete this.options.clientId;
     check(options);
 
     this.guild = options.guild;

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -108,7 +108,12 @@ export class Player {
     if (!this.manager) throw new RangeError("Manager has not been initiated.");
 
     if (this.manager.players.has(options.guild)) {
-      return this.manager.players.get(options.guild);
+      if(this.manager.players.get(options.guild).manager.options.clientId === options.clientId) {
+        return this.manager.players.get(options.guild);
+      } else {
+        this.manager = options.manager;
+      }
+      delete this.options.manager; delete this.options.clientId;
     }
 
     check(options);
@@ -463,6 +468,10 @@ export interface PlayerOptions {
   selfMute?: boolean;
   /** If the player should deaf itself. */
   selfDeafen?: boolean;
+  /** Client Id to check if no corruption is detected. */
+  clientId?: string;
+  /** Manager to set in case corruption is detected. */
+  manager: Manager;
 }
 
 /** If track partials are set some of these will be `undefined` as they were removed. */

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -471,7 +471,7 @@ export interface PlayerOptions {
   /** Client Id to check if no corruption is detected. */
   clientId?: string;
   /** Manager to set in case corruption is detected. */
-  manager: Manager;
+  manager?: Manager;
 }
 
 /** If track partials are set some of these will be `undefined` as they were removed. */


### PR DESCRIPTION
My problem was that I've had two different instances of erela.js running but somehow player-managers shared players of two different bots. (In the same guild) and when I asked bot A to connect, bot B which was already connected took the request.
I don't know how to prevent player sharing, but I fixed the problem of request handling, now it won't be able to take a player from the wrong player-manager.
I know that isn't maybe beautiful but It works and does the job
If someone knew how to fix the problem of shared players from 2 different managers/bots, it would be more helpful than that temporary fix 