### PR TITLE
ci: add publish to npm

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout Project
         uses: actions/checkout@v2
-      - name: Use Node.js 12
+      - name: Use Node.js 16
         uses: actions/setup-node@v1
         with:
           node-version: 16
@@ -58,3 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: MenuDocs
           GITHUB_EMAIL: ${{ secrets.EMAIL }}
+      - name: Publish package to NPM
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
The pr adds feature to publish to npm.
Uses `NPM_AUTH_TOKEN` from the secrets.
It will only publish when version of the package is changed.